### PR TITLE
Spread AF_XDP traffic to all RX queues

### DIFF
--- a/src/compressor_cache_user.c
+++ b/src/compressor_cache_user.c
@@ -447,7 +447,7 @@ struct xdp_umem *xdp_umem_configure(int sfd) {
     return umem;
 }
 
-struct xdp_sock *xsk_configure(struct xdp_umem *umem, int ifindex) {
+struct xdp_sock *xsk_configure(struct xdp_umem *umem, int ifindex, int rxindex) {
     static int ndescs = NUM_DESCS;
 
     struct xdp_sock *xsk = calloc(1, sizeof(struct xdp_sock));
@@ -499,7 +499,7 @@ struct xdp_sock *xsk_configure(struct xdp_umem *umem, int ifindex) {
     struct sockaddr_xdp sxdp = {};
 	sxdp.sxdp_family = AF_XDP;
 	sxdp.sxdp_ifindex = ifindex;
-	sxdp.sxdp_queue_id = 0;
+	sxdp.sxdp_queue_id = rxindex;
 
 	if (umem) {
 		sxdp.sxdp_flags = XDP_SHARED_UMEM;
@@ -522,7 +522,7 @@ void load_skb_program(const char *ifname, int ifindex, int xsk_map_fd, int a2s_i
         num_cpus = MAX_CPUS;
     }
     for (int cpu_id = 0; cpu_id < num_cpus; cpu_id++) {
-        struct xdp_sock *xsk = xsk_configure(NULL, ifindex);
+        struct xdp_sock *xsk = xsk_configure(NULL, ifindex, cpu_id);
         xassert(bpf_map_update_elem(xsk_map_fd, &cpu_id, &xsk->sfd, BPF_ANY) == 0);
         xsk_cache_run(xsk);
     }

--- a/src/compressor_filter_kern.c
+++ b/src/compressor_filter_kern.c
@@ -275,7 +275,7 @@ int xdp_program(struct xdp_md *ctx) {
                     uint8_t *udpdata = data + sizeof(struct ethhdr) + sizeof(struct iphdr) + sizeof(struct udphdr);
                     if (!(udpdata + 5 > (uint8_t *)data_end)) {
                         if (check_srcds_header(udpdata, 0x49) && tunnel_rule->a2s_info_cache) {
-                            return bpf_redirect_map(&xsk_map, bpf_get_smp_processor_id(), 0);
+                            return bpf_redirect_map(&xsk_map, ctx->rx_queue_index, 0);
                         }
                     }
                 }
@@ -291,7 +291,7 @@ int xdp_program(struct xdp_md *ctx) {
 
             return XDP_TX;
         } else {
-            uint32_t cpu_id = bpf_get_smp_processor_id();
+            uint32_t cpu_id = ctx->rx_queue_index;
             void *lru_map = bpf_map_lookup_elem(&rate_limit_map, &cpu_id);
             if (unlikely(lru_map == NULL)) {
                 // How?
@@ -379,7 +379,7 @@ int xdp_program(struct xdp_md *ctx) {
                                         // either way
                                         swap_dest_src_hwaddr(data);
 
-                                        return bpf_redirect_map(&xsk_map, bpf_get_smp_processor_id(), 0);
+                                        return bpf_redirect_map(&xsk_map, ctx->rx_queue_index, 0);
                                     }
 
                                     __sync_fetch_and_add(&entry->misses, 1);


### PR DESCRIPTION
This will spread packets redirected to the AF_XDP socket throughout all RX queues.