### PR TITLE
Allowed non-forwarded ICMP replies

### DIFF
--- a/src/compressor_filter_kern.c
+++ b/src/compressor_filter_kern.c
@@ -442,7 +442,7 @@ int xdp_program(struct xdp_md *ctx) {
                     return forward_packet(ctx, forward_rule, 0x00);
                 }
 
-                return XDP_DROP;
+                return XDP_PASS;
             }
         }
 


### PR DESCRIPTION
This will allow ICMP replies that aren't forwarded to the game server. This is nice for when you want to debug a POP such as running an MTR or ping to the main POP server's IP.