### PR TITLE
Add option to exclude TCP traffic from rate limiting.

### DIFF
--- a/src/compressor.c
+++ b/src/compressor.c
@@ -82,8 +82,17 @@ int main(int argc, char **argv) {
             rate_limit = 12000;
             fprintf(stderr, "Warning: no rate limit set; defaulting to 12000\n");
         }
+
+        int tcp_exclude = 0;
+
+        if (config_lookup_int(&config, "tcp_exclude", &tcp_exclude) == CONFIG_FALSE)
+        {
+            tcp_exclude = 0;
+        }
+
         cfg.rate_limit = rate_limit;
         cfg.new_conn_limit = new_conn_limit;
+        cfg.tcp_exclude = tcp_exclude;
 
         int cockpit_enabled = 0;
         config_lookup_bool(&config, "cockpit_enabled", &cockpit_enabled);

--- a/src/compressor_filter_kern.c
+++ b/src/compressor_filter_kern.c
@@ -298,6 +298,23 @@ int xdp_program(struct xdp_md *ctx) {
                 return XDP_ABORTED;
             }
 
+            // Check for TCP exclude.
+            if (cfg->tcp_exclude == 1 && iph->protocol == IPPROTO_TCP)
+            {
+                struct tcphdr *tcph = (data + sizeof(struct ethhdr) + (iph->ihl * 4));
+
+                if (tcph + 1 > (struct tcphdr *)data_end)
+                {
+                    return XDP_DROP;
+                }
+
+                // Check to make sure SYN flag isn't set so we exclude SYN-related attacks.
+                if (tcph->syn == 0)
+                {
+                    goto endratelimit;
+                }
+            }
+
             struct ip_addr_history *last_seen = bpf_map_lookup_elem(lru_map, &iph->saddr);
             uint64_t now = bpf_ktime_get_ns();
             if (!last_seen) {
@@ -335,6 +352,8 @@ int xdp_program(struct xdp_md *ctx) {
                     return XDP_DROP;
                 }
             }
+
+            endratelimit:
 
             if (iph->protocol == IPPROTO_UDP) {
                 struct udphdr *udph = data + sizeof(struct ethhdr) + sizeof(struct iphdr);

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,7 @@
 struct config {
     uint_fast64_t new_conn_limit;
     uint_fast64_t rate_limit;
+    uint_fast8_t tcp_exclude;
 };
 
 struct forwarding_rule {


### PR DESCRIPTION
This pull request adds an option named `tcp_exclude`. When set, it excludes all TCP traffic from rate limiting that doesn't have the `SYN` flag set (attempting to exclude SYN-related flood attacks).