### PR TITLE
Add XDP-native support.

### DIFF
--- a/src/compressor.c
+++ b/src/compressor.c
@@ -67,8 +67,8 @@ int main(int argc, char **argv) {
             perror("Error getting interface");
             return 1;
         }
+        bpf_set_link_xdp_fd(ifindex, -1, XDP_FLAGS_DRV_MODE);
         bpf_set_link_xdp_fd(ifindex, -1, XDP_FLAGS_SKB_MODE);
-
 
         struct config cfg = { 0 };
         long long new_conn_limit = 0;


### PR DESCRIPTION
This pull request adds XDP-native support to Compressor. It tries XDP-native first and if there's any error with attaching to the interface, it'll try with XDP-generic. As of right now, it does not suppress the first error when it can't attach via XDP-native. Therefore, output will look similar to:

```
Kernel error message: virtio_net: Too few free TX rings available
Didn't work with XDP-native. Trying XDP-generic (SKB mode).
```

I'm not sure how to disable that error sadly. I've also confirmed XDP-native works from testing this on a VM with Vultr that has XDP-native support.

For those that do not know, XDP-native is a lot faster than XDP-generic. It's true XDP, but only some NIC drivers support it. A list of driver support can be found [here](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp).