### PR TITLE
Add SKB/XDP-Generic Force Option.

### DIFF
--- a/src/compressor.c
+++ b/src/compressor.c
@@ -90,9 +90,17 @@ int main(int argc, char **argv) {
             tcp_exclude = 0;
         }
 
+        int force_skb = 0;
+
+        if (config_lookup_int(&config, "force_skb", &force_skb) == CONFIG_FALSE)
+        {
+            force_skb = 0;
+        }
+
         cfg.rate_limit = rate_limit;
         cfg.new_conn_limit = new_conn_limit;
         cfg.tcp_exclude = tcp_exclude;
+        cfg.force_skb = force_skb;
 
         int cockpit_enabled = 0;
         config_lookup_bool(&config, "cockpit_enabled", &cockpit_enabled);

--- a/src/compressor_filter_user.c
+++ b/src/compressor_filter_user.c
@@ -203,9 +203,18 @@ struct compressor_maps *load_xdp_prog(struct forwarding_rule **forwarding, struc
     signal(SIGKILL, int_exit);
     atexit(cleanup_interface);
 
-    if (bpf_set_link_xdp_fd(ifindex, prog_fd[0], XDP_FLAGS_DRV_MODE) < 0) {
+    if (cfg->force_skb || bpf_set_link_xdp_fd(ifindex, prog_fd[0], XDP_FLAGS_DRV_MODE) < 0) {
         // Try XDP-generic (SKB-mode).
-        fprintf(stderr, "Didn't work with XDP-native. Trying XDP-generic (SKB mode).\n");
+
+        if (cfg->force_skb)
+        {
+            fprintf(stdout, "Ignoring XDP-native (DRV mode).\n");
+        }
+        else
+        {
+            fprintf(stderr, "Didn't work with XDP-native. Trying XDP-generic (SKB mode).\n");
+        }
+        
         if (bpf_set_link_xdp_fd(ifindex, prog_fd[0], XDP_FLAGS_SKB_MODE) < 0) {
             fprintf(stderr, "link set xdp failed\n");
             return 0;

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,7 @@ struct config {
     uint_fast64_t new_conn_limit;
     uint_fast64_t rate_limit;
     uint_fast8_t tcp_exclude;
+    uint_fast8_t force_skb;
 };
 
 struct forwarding_rule {


### PR DESCRIPTION
This pull request adds an option to force SKB/XDP-generic mode. I added this option because when my Vultr VM runs Compressor with XDP-native mode, it broke A2S_INFO caching. One other experienced this issue as well.

For me, it appears XDP-native sends traffic over a different RX queue (ID 1) while XDP-generic sends traffic over RX queue ID 0.

With that said, I've tried redirecting traffic from the XDP program to AF_XDP program over queue ID 1 while in XDP-native. I've confirmed the AF_XDP socket does receive the packets, but it isn't sending the A2S_INFO response back to the client. It does appear it is able to get the A2S_INFO response from the game server, though. Also, for some reason I cannot bind to the same RX queue via AF_XDP after the first Compressor run. I receive a "Device/Resource is too busy" error and have to restart the VM after the initial Compressor run to resolve this. I've tried adding code to close the XSK socket(s) and different kernels, but no luck.

I believe the main issue is due to outdated AF_XDP code. Compressor is using different/outdated AF_XDP code than what I've seen online and LibBPF was also outdated (I got Compressor working with the new LibBPF though and if I find a way to resolve the issue with writing new code, I'll add another pull request).

Thanks.